### PR TITLE
Support HeatPump

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * In the "Category" field, select "Integration".
     * Click "Add".
 3.  ** Edit Code: **
-    * You must edit sensor.py and number.py
-    * You will see `chlorinator_id = "-1"` and `heatpump_id = "0"`
+    * You must edit const.py
+    * You will see `CHLORINATOR_ID = "-1"` and `HEATPUMP_ID = "0"`
     * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"
     * If you only have one, it will be "0"
     * If you have both, try clorinator "0" and heatpump "1", or try clorinator "1" and heatpump "0"
+    * After edding code, you must restart home assistant
 5.  **Install Integration:**
     * Search for "PoolSync Custom" in HACS (it might take a moment to appear after adding the custom repository).
     * Click "Install".
     * Restart Home Assistant when prompted.
+    * If you already done the push-button linking, you can edit the IDs and restart home assistant and do not need to redo the linking procedure
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ If you want a simple switch to turn heater on/off:
    * Set value template to `{{is_state('sensor.poolsync_XXXXX_mode', '1')}}` where XXXX is the MAC of your poolsync (should come up if type poolsync)
    * Change `on action` to number, entity number.poolsync_heat_mode to 1
    * Change `off action` to number, entity number.poolsync_heat_mode to 0
+   * Associate with the poolsync device under Device (show it shows in the integration page)
    * You can make another swtich with on action to 2 if you want cool mode
    * Remember, setting to heat/cool will reset the temperature back to 68F (not sure what is C), so you need to set the temp again after turning heat on
+     
 If you want a sensor that shows if set to Off/Heat/Cool
    * Make a switch template (Settings->Devices & Servies-> Helpers Tab). type template, then select sensor template
    * Set value template to below where XXXX is the MAC of your poolsync (should come up if type poolsync)
@@ -111,7 +113,8 @@ If you want a sensor that shows if set to Off/Heat/Cool
           {% else %} Unknown
           {% endif %}
    ```
-
+   * Associate with the poolsync device under Device (show it shows in the integration page)
+     
 ## Options
 
 After setting up the integration, you can adjust the polling interval:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This integration will create several entities, including (but not limited to):
 * **Number Controls:**
     * Chlorinator Output (allows setting the output percentage, typically 0-100%)
     * HeatPump Temperature Set Point (allows setting the output percentage, typically 40-104 F)
-    * HeatPump Mode (0-off, 1-on, 2-cool)
+    * HeatPump Mode (0-off, 1-on, 2-cool) - Setting to 1 will change set point to 68F. You must then set temperature manaully
 
 The exact entities will depend on the data reported by your specific PoolSync model and firmware. Some diagnostic entities may be disabled by default and can be enabled via the entity settings in Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * In the "Repository" field, paste the URL of this GitHub repository (e.g., `https://github.com/YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME`).
     * In the "Category" field, select "Integration".
     * Click "Add".
-3.  **Install Integration:**
+3.  ** Edit Code: **
+    * You must edit sensor.py and number.py
+    * You will see `chlorinator_id = "-1"` and `heatpump_id = "0"`
+    * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"
+    * If you only have one, it will be "0"
+    * If you have both, try clorinator "0" and heatpump "1", or try clorinator "1" and heatpump "0"
+5.  **Install Integration:**
     * Search for "PoolSync Custom" in HACS (it might take a moment to appear after adding the custom repository).
     * Click "Install".
     * Restart Home Assistant when prompted.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ This integration will create several entities, including (but not limited to):
     * HeatPump Mode (0-off, 1-on, 2-cool) - Setting to 1 will change set point to 68F. You must then set temperature manaully
 
 The exact entities will depend on the data reported by your specific PoolSync model and firmware. Some diagnostic entities may be disabled by default and can be enabled via the entity settings in Home Assistant.
-
+## Templates
+If you want a simple switch to turn heater on/off:
+   * Make a switch template (Settings->Devices & Servies-> Helpers Tab). type template, then select switch template
+   * Set value template to `{{is_state('sensor.poolsync_XXXXX_mode', '1')}}` where XXXX is the MAC of your poolsync (should come up if type poolsync)
+   * Change `on action` to number, entity number.poolsync_heat_mode to 1
+   * Change `off action` to number, entity number.poolsync_heat_mode to 0
 ## Options
 
 After setting up the integration, you can adjust the polling interval:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This integration will create several entities, including (but not limited to):
     * System Fault Status
     * ChlorSync Fault Status
     * Service Mode Active
+    * Heat Pump Fan
+    * Heat Pump Compressor
+    * Heat Pump Flow 
 * **Number Controls:**
     * Chlorinator Output (allows setting the output percentage, typically 0-100%)
     * HeatPump Temperature Set Point (allows setting the output percentage, typically 40-104 F)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ If you want a simple switch to turn heater on/off:
    * Set value template to `{{is_state('sensor.poolsync_XXXXX_mode', '1')}}` where XXXX is the MAC of your poolsync (should come up if type poolsync)
    * Change `on action` to number, entity number.poolsync_heat_mode to 1
    * Change `off action` to number, entity number.poolsync_heat_mode to 0
+If you want a sensor that shows if set to Off/Heat/Cool
+   * Make a switch template (Settings->Devices & Servies-> Helpers Tab). type template, then select sensor template
+   * Set value template to below where XXXX is the MAC of your poolsync (should come up if type poolsync)
+   ```
+      {% set t = states('sensor.poolsync_XXX_mode') | int(0) %}
+          {% if t == 0 %} Off
+          {% elif t == 1 %} Heat
+          {% elif t == 2 %} Cool
+          {% else %} Unknown
+          {% endif %}
+   ```
+
 ## Options
 
 After setting up the integration, you can adjust the polling interval:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * You will be prompted to enter the local IP address of your PoolSync device. Click "Submit".
 5.  **Push-Button Linking:**
     * The integration will attempt to initiate the linking process by sending a command to your PoolSync device.
-    * You will be prompted to **press the "Service" button on your PoolSync device**.
+    * You will be prompted to **press the "Service" button on your PoolSync device**. (Sometimes this does not show, and only shows a submit button)
     * The configuration flow will show the approximate time remaining to press the button.
     * Once the button is pressed and the device responds, the integration will retrieve an access password and the device's MAC address.
 6.  **Setup Complete:**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
 
-This is a custom integration for Home Assistant to monitor and control AutoPilot PoolSync pool chlorinators over the local network. It does not rely on any cloud services.
+This is a custom integration for Home Assistant to monitor and control AutoPilot PoolSync pool chlorinators and heat pumps over the local network. It does not rely on any cloud services.
 
 ## Features
 
@@ -71,7 +71,7 @@ This integration will create several entities, including (but not limited to):
     * Chlorinator Output Setting (current setting read from device)
     * Boost Time Remaining
     * Various diagnostic sensors (Wi-Fi RSSI, board temperature, cell currents/voltages, firmware versions - some may be disabled by default).
-* **Sensors (HeatPump):**
+* **Sensors (HeatPump):** Thanks to @ccpk1 and others on home assistant forum
     * Water Temperature
     * Setpoint Temperature
     * Output Temperature

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * In the "Repository" field, paste the URL of this GitHub repository (e.g., `https://github.com/YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME`).
     * In the "Category" field, select "Integration".
     * Click "Add".
-3.  ** Edit Code: **
+3.  **Edit Code:**
     * You must edit const.py
     * You will see `CHLORINATOR_ID = "-1"` and `HEATPUMP_ID = "0"`
     * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
 3.  **Edit Code:**
     * You must edit const.py
     * You will see `CHLORINATOR_ID = "-1"` and `HEATPUMP_ID = "0"`
+    * Above settings will work if you only have a HeatPump 
     * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"
     * If you only have one, the one you have will be "0"
     * If you have both, try clorinator "0" and heatpump "1", or try clorinator "1" and heatpump "0"

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Configure these in your `configuration.yaml` as per the Home Assistant documenta
 * If linking fails, try restarting the PoolSync device and then attempt the configuration again.
 * Check Home Assistant logs (Settings > System > Logs) for any error messages related to `poolsync_custom`. Enable debug logging for `custom_components.poolsync_custom` if needed (see Home Assistant documentation on how to set logger levels).
 * Use the Diagnostics feature (on the device page in HA, click the three dots, then "Download diagnostics") to download raw data from the integration, which can be helpful for debugging.
+* If your connection drops out (connection reset by peer error), a stronger WiFi signal is needed. Get an extender/mesh network. Ensure it is connected to the closest node in your mesh.  Hitting the reboot button on the PoolSync will fix it temporarily until you can get a better signal.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * You must edit const.py
     * You will see `CHLORINATOR_ID = "-1"` and `HEATPUMP_ID = "0"`
     * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"
-    * If you only have one, it will be "0"
+    * If you only have one, the one you have will be "0"
     * If you have both, try clorinator "0" and heatpump "1", or try clorinator "1" and heatpump "0"
-    * After edding code, you must restart home assistant
+    * After editing code, you must restart home assistant
 5.  **Install Integration:**
     * Search for "PoolSync Custom" in HACS (it might take a moment to appear after adding the custom repository).
     * Click "Install".

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This integration will create several entities, including (but not limited to):
 * **Number Controls:**
     * Chlorinator Output (allows setting the output percentage, typically 0-100%)
     * HeatPump Temperature Set Point (allows setting the output percentage, typically 40-104 F)
-    * HeatPump Mode (0-off, 1-on, 2-cool) - Setting to 1 will change set point to 68F. You must then set temperature manaully
+    * HeatPump Mode (0-off, 1-on, 2-cool)
 
 The exact entities will depend on the data reported by your specific PoolSync model and firmware. Some diagnostic entities may be disabled by default and can be enabled via the entity settings in Home Assistant.
 ## Templates
@@ -101,7 +101,6 @@ If you want a simple switch to turn heater on/off:
    * Change `off action` to number, entity number.poolsync_heat_mode to 0
    * Associate with the poolsync device under Device (optional: this will make it show in the integration's list of entities)
    * You can make another swtich with on action to 2 if you want cool mode
-   * Remember, setting to heat/cool will reset the temperature back to 68F (not sure what is C), so you need to set the temp again after turning heat on
      
 If you want a sensor that shows if set to Off/Heat/Cool
    * Make a switch template (Settings->Devices & Servies-> Helpers Tab). type template, then select sensor template

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
 * Creates sensors in Home Assistant for key metrics (e.g., water temperature, salt PPM, flow rate, device status).
 * Creates binary sensors for online status and other states like faults or service mode.
 * **Control Chlorinator Output:** Allows setting the chlorine output percentage via a number entity.
+* **Control Heatpump Output:** Allows setting the temperature and mode via a number entity.
 * Configurable update interval via an options flow.
 
 ## Prerequisites
@@ -54,13 +55,18 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
 
 This integration will create several entities, including (but not limited to):
 
-* **Sensors:**
+* **Sensors (ChlorSync):**
     * Water Temperature
     * Salt Level (PPM)
     * Flow Rate
     * Chlorinator Output Setting (current setting read from device)
     * Boost Time Remaining
     * Various diagnostic sensors (Wi-Fi RSSI, board temperature, cell currents/voltages, firmware versions - some may be disabled by default).
+* **Sensors (HeatPump):**
+    * Water Temperature
+    * Setpoint Temperature
+    * Output Temperature
+    * Mode (0-off, 1-heat, 2-cool)
 * **Binary Sensors:**
     * PoolSync Online Status
     * ChlorSync Module Online Status
@@ -69,6 +75,8 @@ This integration will create several entities, including (but not limited to):
     * Service Mode Active
 * **Number Controls:**
     * Chlorinator Output (allows setting the output percentage, typically 0-100%)
+    * HeatPump Temperature Set Point (allows setting the output percentage, typically 40-104 F)
+    * HeatPump Mode (0-off, 1-on, 2-cool)
 
 The exact entities will depend on the data reported by your specific PoolSync model and firmware. Some diagnostic entities may be disabled by default and can be enabled via the entity settings in Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ This is a custom integration for Home Assistant to monitor and control AutoPilot
     * In the "Repository" field, paste the URL of this GitHub repository (e.g., `https://github.com/YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME`).
     * In the "Category" field, select "Integration".
     * Click "Add".
-3.  **Edit Code:**
-    * You must edit const.py
+3.  **Edit Code:** (Should no loger be needed!!)
+    * If the code does not find your Heatpump/Chloronator, you must edit const.py to help
     * You will see `CHLORINATOR_ID = "-1"` and `HEATPUMP_ID = "0"`
     * Above settings will work if you only have a HeatPump 
     * If you do not have a chlorinator or heatpump, set the corresponding id to "-1"
     * If you only have one, the one you have will be "0"
     * If you have both, try clorinator "0" and heatpump "1", or try clorinator "1" and heatpump "0"
     * After editing code, you must restart home assistant
+    * This should no longer be needed, but I leave it just in case.
 5.  **Install Integration:**
     * Search for "PoolSync Custom" in HACS (it might take a moment to appear after adding the custom repository).
     * Click "Install".

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you want a simple switch to turn heater on/off:
    * Set value template to `{{is_state('sensor.poolsync_XXXXX_mode', '1')}}` where XXXX is the MAC of your poolsync (should come up if type poolsync)
    * Change `on action` to number, entity number.poolsync_heat_mode to 1
    * Change `off action` to number, entity number.poolsync_heat_mode to 0
+   * You can make another swtich with on action to 2 if you want cool mode
+   * Remember, setting to heat/cool will reset the temperature back to 68F (not sure what is C), so you need to set the temp again after turning heat on
 If you want a sensor that shows if set to Off/Heat/Cool
    * Make a switch template (Settings->Devices & Servies-> Helpers Tab). type template, then select sensor template
    * Set value template to below where XXXX is the MAC of your poolsync (should come up if type poolsync)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you want a simple switch to turn heater on/off:
    * Set value template to `{{is_state('sensor.poolsync_XXXXX_mode', '1')}}` where XXXX is the MAC of your poolsync (should come up if type poolsync)
    * Change `on action` to number, entity number.poolsync_heat_mode to 1
    * Change `off action` to number, entity number.poolsync_heat_mode to 0
-   * Associate with the poolsync device under Device (show it shows in the integration page)
+   * Associate with the poolsync device under Device (optional: this will make it show in the integration's list of entities)
    * You can make another swtich with on action to 2 if you want cool mode
    * Remember, setting to heat/cool will reset the temperature back to 68F (not sure what is C), so you need to set the temp again after turning heat on
      
@@ -114,7 +114,7 @@ If you want a sensor that shows if set to Off/Heat/Cool
           {% else %} Unknown
           {% endif %}
    ```
-   * Associate with the poolsync device under Device (show it shows in the integration page)
+   * Associate with the poolsync device under Device (optional: this will make it show in the integration's list of entities)
      
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This integration will create several entities, including (but not limited to):
     * Water Temperature
     * Setpoint Temperature
     * Output Temperature
+    * Air Temperature
     * Mode (0-off, 1-heat, 2-cool)
 * **Binary Sensors:**
     * PoolSync Online Status
@@ -81,6 +82,7 @@ This integration will create several entities, including (but not limited to):
     * System Fault Status
     * ChlorSync Fault Status
     * Service Mode Active
+    * HeatPump Module Online Status
     * Heat Pump Fan
     * Heat Pump Compressor
     * Heat Pump Flow 

--- a/custom_components/poolsync_custom/__init__.py
+++ b/custom_components/poolsync_custom/__init__.py
@@ -25,7 +25,7 @@ from .const import (
 from .coordinator import PoolSyncDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
+        
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PoolSync Custom from a config entry."""
     _LOGGER.info(

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -53,6 +53,113 @@ class PoolSyncApiClient:
         self._base_url = f"http://{self._ip_address}"
         _LOGGER.debug("PoolSyncApiClient initialized for IP: %s", self._ip_address)
 
+    async def _request_patch(
+        
+        self,
+        deviceId,
+        keyId,
+        value,
+        password: Optional[str] = None,
+        
+    ) -> Dict[str, Any]:
+        """
+        Make an HTTP request to the PoolSync device.
+
+        Args:
+            method: HTTP method (GET, PUT).
+            path: API endpoint path.
+            password: Optional password for authorization.
+
+        Returns:
+            A dictionary containing the JSON response from the API.
+
+        Raises:
+            PoolSyncApiCommunicationError: If there's a network or device communication issue.
+            PoolSyncApiAuthError: If the server returns a 401 or 403 error.
+            PoolSyncApiError: For other HTTP errors or invalid JSON response.
+        """
+        path = '/api/poolsync'
+        url = f"{self._base_url}{path}"
+        _LOGGER.info(url)
+        headers = {
+            "User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
+            "Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
+            HEADER_USER: USER_HEADER_VALUE,
+            "Connection": "keep-alive", # As per curl example
+            "Accept-Encoding": "gzip, deflate, br", # As per curl example
+            # Host header is automatically set by aiohttp
+        }
+        if password:
+            headers[HEADER_AUTHORIZATION] = password
+
+        params = {
+           'cmd': 'devices',
+           'device': deviceId,
+        }
+
+        #json_data = {}
+        #json_data[keyId] = int(value)
+        json_data = {
+            'config': {
+                'setpoint': 68,
+            },
+        }
+        json_data['config'][keyId] = int(value)
+
+        
+        _LOGGER.info(params)
+        _LOGGER.info(json_data)
+        
+        try:
+            async with self._session.patch(url, params=params, headers=headers, json=json_data, timeout=HTTP_TIMEOUT
+            ) as response:
+                response_text = await response.text() # Read text first for logging/errors
+                _LOGGER.debug(
+                    "Response from %s: Status: %s, Content-Type: %s, Body snippet: %s",
+                    url,
+                    response.status,
+                    response.headers.get("Content-Type"),
+                    response_text[:200] # Log a snippet of the response body
+                )
+
+                if response.status == 200:
+                    # PoolSync devices sometimes return non-standard JSON content types like 'text/plain'
+                    # but the body is still JSON. We'll try to parse JSON regardless of content-type if status is 200.
+                    try:
+                        json_response = await response.json(content_type=None) # Try to parse JSON regardless of reported type
+                        _LOGGER.debug("Successfully parsed JSON response: %s", json_response)
+                        return json_response
+                    except (ValueError, aiohttp.ContentTypeError) as e: # Catches json.JSONDecodeError and content type issues
+                        _LOGGER.error("Failed to decode JSON response from %s despite 200 OK. Error: %s. Body: %s", url, e, response_text)
+                        raise PoolSyncApiError(f"Invalid JSON response: {e}", status_code=response.status, body=response_text) from e
+                elif response.status in (401, 403):
+                    _LOGGER.error("Authentication error from %s: %s. Body: %s", url, response.status, response_text)
+                    raise PoolSyncApiAuthError(
+                        f"Authentication failed: {response.status}", status_code=response.status, body=response_text
+                    )
+                else:
+                    _LOGGER.error(
+                        "HTTP error from %s: %s - %s. Body: %s", url, response.status, response.reason, response_text
+                    )
+                    raise PoolSyncApiError(
+                        f"HTTP error {response.status}: {response.reason}", status_code=response.status, body=response_text
+                    )
+        except ClientConnectorError as e:
+            _LOGGER.error("Network connection error for %s: %s", self._ip_address, e)
+            raise PoolSyncApiCommunicationError(
+                f"Cannot connect to PoolSync device at {self._ip_address}: {e}"
+            ) from e
+        except asyncio.TimeoutError as e: # This is for the overall request timeout
+            _LOGGER.error("Request timed out for %s accessing %s", self._ip_address, url)
+            raise PoolSyncApiCommunicationError(
+                f"Request to {url} timed out after {HTTP_TIMEOUT}s"
+            ) from e
+        # ClientResponseError is a base for many client-side errors, already caught by status checks.
+        # Catching broader Exception for any other unexpected aiohttp or network issues.
+        except Exception as e:
+            _LOGGER.exception("An unexpected error occurred during API request to %s for URL %s: %s", self._ip_address, url, e)
+            raise PoolSyncApiError(f"An unexpected error occurred: {e}") from e
+    
     async def _request(
         self,
         method: str,

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -165,7 +165,7 @@ class PoolSyncApiClient:
         """
         _LOGGER.debug("Querying push-link status for %s.", self._ip_address)
         response = await self._request("GET", API_PATH_PUSHLINK_STATUS)
-        _LOGGER.info(response.json())
+        _LOGGER.info(response)
         # Expected keys: "timeRemaining" or "password" and "macAddress"
         return response
 
@@ -182,7 +182,6 @@ class PoolSyncApiClient:
         _LOGGER.debug("Fetching all data for %s with password.", self._ip_address)
         response = await self._request("GET", API_PATH_ALL_DATA, password=password)
         
-        _LOGGER.info(response.json())
         # Basic validation of the expected top-level key
         if "poolSync" not in response or not isinstance(response.get("poolSync"), dict):
             _LOGGER.error("Main 'poolSync' key missing or not a dictionary in data response for %s: %s", self._ip_address, response)

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -85,7 +85,7 @@ class PoolSyncApiClient:
             "User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
             "Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
             HEADER_USER: USER_HEADER_VALUE,
-            "Connection": "keep-alive", # As per curl example
+            #"Connection": "keep-alive", # As per curl example
             "Accept-Encoding": "gzip, deflate, br", # As per curl example
             # Host header is automatically set by aiohttp
         }
@@ -97,11 +97,11 @@ class PoolSyncApiClient:
            'device': deviceId,
         }
 
-        #json_data = {}
+        
         #json_data[keyId] = int(value)
         json_data = {
             'config': {
-                'setpoint': 68,
+                #'setpoint': 68,
             },
         }
         json_data['config'][keyId] = int(value)
@@ -166,7 +166,7 @@ class PoolSyncApiClient:
             "User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
             "Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
             HEADER_USER: USER_HEADER_VALUE,
-            "Connection": "keep-alive", # As per curl example
+            #"Connection": "keep-alive", # As per curl example
             "Accept-Encoding": "gzip, deflate, br", # As per curl example
             # Host header is automatically set by aiohttp
         }

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -165,6 +165,7 @@ class PoolSyncApiClient:
         """
         _LOGGER.debug("Querying push-link status for %s.", self._ip_address)
         response = await self._request("GET", API_PATH_PUSHLINK_STATUS)
+        _LOGGER.info(response.json())
         # Expected keys: "timeRemaining" or "password" and "macAddress"
         return response
 
@@ -180,7 +181,8 @@ class PoolSyncApiClient:
 
         _LOGGER.debug("Fetching all data for %s with password.", self._ip_address)
         response = await self._request("GET", API_PATH_ALL_DATA, password=password)
-
+        
+        _LOGGER.info(response.json())
         # Basic validation of the expected top-level key
         if "poolSync" not in response or not isinstance(response.get("poolSync"), dict):
             _LOGGER.error("Main 'poolSync' key missing or not a dictionary in data response for %s: %s", self._ip_address, response)

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -122,28 +122,6 @@ class PoolSyncApiClient:
                     response_text[:200] # Log a snippet of the response body
                 )
 
-                if response.status == 200:
-                    # PoolSync devices sometimes return non-standard JSON content types like 'text/plain'
-                    # but the body is still JSON. We'll try to parse JSON regardless of content-type if status is 200.
-                    try:
-                        json_response = await response.json(content_type=None) # Try to parse JSON regardless of reported type
-                        _LOGGER.debug("Successfully parsed JSON response: %s", json_response)
-                        return json_response
-                    except (ValueError, aiohttp.ContentTypeError) as e: # Catches json.JSONDecodeError and content type issues
-                        _LOGGER.error("Failed to decode JSON response from %s despite 200 OK. Error: %s. Body: %s", url, e, response_text)
-                        raise PoolSyncApiError(f"Invalid JSON response: {e}", status_code=response.status, body=response_text) from e
-                elif response.status in (401, 403):
-                    _LOGGER.error("Authentication error from %s: %s. Body: %s", url, response.status, response_text)
-                    raise PoolSyncApiAuthError(
-                        f"Authentication failed: {response.status}", status_code=response.status, body=response_text
-                    )
-                else:
-                    _LOGGER.error(
-                        "HTTP error from %s: %s - %s. Body: %s", url, response.status, response.reason, response_text
-                    )
-                    raise PoolSyncApiError(
-                        f"HTTP error {response.status}: {response.reason}", status_code=response.status, body=response_text
-                    )
         except ClientConnectorError as e:
             _LOGGER.error("Network connection error for %s: %s", self._ip_address, e)
             raise PoolSyncApiCommunicationError(

--- a/custom_components/poolsync_custom/api.py
+++ b/custom_components/poolsync_custom/api.py
@@ -80,13 +80,14 @@ class PoolSyncApiClient:
         """
         path = '/api/poolsync'
         url = f"{self._base_url}{path}"
-        _LOGGER.info(url)
         headers = {
-            "User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
-            "Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
+            #"User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
+            #"Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
+            "Content-Type": "application/json",
             HEADER_USER: USER_HEADER_VALUE,
             #"Connection": "keep-alive", # As per curl example
-            "Accept-Encoding": "gzip, deflate, br", # As per curl example
+            #"Accept-Encoding": "gzip, deflate, br", # As per curl example
+            "Accept-Encoding": "gzip, deflate", # As per curl example
             # Host header is automatically set by aiohttp
         }
         if password:
@@ -105,10 +106,6 @@ class PoolSyncApiClient:
             },
         }
         json_data['config'][keyId] = int(value)
-
-        
-        _LOGGER.info(params)
-        _LOGGER.info(json_data)
         
         try:
             async with self._session.patch(url, params=params, headers=headers, json=json_data, timeout=HTTP_TIMEOUT
@@ -163,11 +160,11 @@ class PoolSyncApiClient:
         """
         url = f"{self._base_url}{path}"
         headers = {
-            "User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
-            "Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
+            #"User-Agent": "HomeAssistant-PoolSyncCustom/0.1.0", # Match version in manifest
+            #"Accept": "application/json, text/plain, */*", # Broader accept based on some device behaviors
             HEADER_USER: USER_HEADER_VALUE,
             #"Connection": "keep-alive", # As per curl example
-            "Accept-Encoding": "gzip, deflate, br", # As per curl example
+            #"Accept-Encoding": "gzip, deflate, br", # As per curl example
             # Host header is automatically set by aiohttp
         }
         if password:

--- a/custom_components/poolsync_custom/binary_sensor.py
+++ b/custom_components/poolsync_custom/binary_sensor.py
@@ -73,16 +73,26 @@ async def async_setup_entry(
     if not coordinator.data or not (isinstance(coordinator.data.get("poolSync"), dict) and isinstance(coordinator.data.get("devices"), dict)):
         _LOGGER.warning("Coordinator %s: Initial data is missing 'poolSync' or 'devices' top-level keys. Binary sensor setup may be incomplete.", coordinator.name)
     
-    
+    heatpump_id = HEATPUMP_ID
+    chlor_id = CHLORINATOR_ID
+    if coordinator.data and isinstance(coordinator.data.get("deviceType"), dict):
+        deviceTypes = coordinator.data.get("deviceType")
+        temp = [key for key, value in deviceTypes.items() if value == "heatPump"]
+        heatpump_id = temp[0] if temp else "-1"
+        temp = [key for key, value in deviceTypes.items() if value == "chlorSync"]
+        chlor_id = temp[0] if temp else "-1"
+        
     for description, data_path, value_fn in BINARY_SENSOR_DESCRIPTIONS_POOLSYNC:
         binary_sensors_to_add.append(PoolSyncBinarySensor(coordinator, description, data_path, value_fn))
     
-    if CHLORINATOR_ID != "-1" : 
+    if chlor_id != "-1":
         for description, data_path, value_fn in BINARY_SENSOR_DESCRIPTIONS_CHLORSYNC:
+            data_path[1] = chlor_id
             binary_sensors_to_add.append(PoolSyncBinarySensor(coordinator, description, data_path, value_fn))
            
-    if HEATPUMP_ID != "-1" : 
+    if heatpump_id != "-1":
         for description, data_path, value_fn in BINARY_SENSOR_DESCRIPTIONS_HEATPUMP:
+            data_path[1] = heatpump_id
             binary_sensors_to_add.append(PoolSyncBinarySensor(coordinator, description, data_path, value_fn))       
 
     if binary_sensors_to_add:

--- a/custom_components/poolsync_custom/binary_sensor.py
+++ b/custom_components/poolsync_custom/binary_sensor.py
@@ -54,13 +54,13 @@ BINARY_SENSOR_DESCRIPTIONS_HEATPUMP: Tuple[Tuple[BinarySensorEntityDescription, 
         key="heatpump_fault", name="HeatPump Module Fault", device_class=BinarySensorDeviceClass.PROBLEM, entity_registry_enabled_default=True,
     ), ["devices", HEATPUMP_ID, "faults"], lambda v: isinstance(v, list) and any(fault_code != 0 for fault_code in v)), # CORRECTED PATH
     (BinarySensorEntityDescription(
-        key="heatpump_flow", name="HeatPump Flow", device_class=BinarySensorDeviceClass.RUNNING, entity_registry_enabled_default=True,
+        key="heatpump_flow", name="HeatPump Flow", entity_registry_enabled_default=True,
     ), ["devices", HEATPUMP_ID, "status", "ctrlFlags"], lambda v: bool(v >= 1) if isinstance(v, (bool, int)) else None),
     (BinarySensorEntityDescription(
-        key="heatpump_compressor", name="HeatPump Compressor", device_class=BinarySensorDeviceClass.RUNNING, entity_registry_enabled_default=True,
+        key="heatpump_compressor", name="HeatPump Compressor", entity_registry_enabled_default=True,
     ), ["devices", HEATPUMP_ID, "status", "stateFlags"], lambda v: bool(v == 8) if isinstance(v, (bool, int)) else None),
     (BinarySensorEntityDescription(
-        key="heatpump_fan", name="HeatPump Fan", device_class=BinarySensorDeviceClass.RUNNING, entity_registry_enabled_default=True,
+        key="heatpump_fan", name="HeatPump Fan",entity_registry_enabled_default=True,
     ), ["devices", HEATPUMP_ID, "status", "stateFlags"], lambda v: bool(v == 8 or v == 520) if isinstance(v, (bool, int)) else None),
 )
 

--- a/custom_components/poolsync_custom/config_flow.py
+++ b/custom_components/poolsync_custom/config_flow.py
@@ -166,7 +166,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={}, # Errors are handled by the re-entry with user_input containing an error
         )
 
-    async def _async_poll_for_password(self) -> None:
+async def _async_poll_for_password(self) -> None:
         """Poll the device for pushlink status until password is received or timeout."""
         _LOGGER.debug("ConfigFlow: Starting password polling loop for %s.", self._ip_address)
         if not self._api_client or not self._ip_address:

--- a/custom_components/poolsync_custom/config_flow.py
+++ b/custom_components/poolsync_custom/config_flow.py
@@ -166,7 +166,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={}, # Errors are handled by the re-entry with user_input containing an error
         )
 
-async def _async_poll_for_password(self) -> None:
+    async def _async_poll_for_password(self) -> None:
         """Poll the device for pushlink status until password is received or timeout."""
         _LOGGER.debug("ConfigFlow: Starting password polling loop for %s.", self._ip_address)
         if not self._api_client or not self._ip_address:

--- a/custom_components/poolsync_custom/const.py
+++ b/custom_components/poolsync_custom/const.py
@@ -3,6 +3,9 @@
 # Domain for the integration (must match folder name and manifest.json)
 DOMAIN = "poolsync_custom"
 
+CHLORINATOR_ID = "-1"
+HEATPUMP_ID = "0"
+
 # Configuration keys used in config_flow and config_entry
 CONF_IP_ADDRESS = "ip_address"
 CONF_PASSWORD = "password" # Stored in config entry after successful linking

--- a/custom_components/poolsync_custom/const.py
+++ b/custom_components/poolsync_custom/const.py
@@ -22,7 +22,7 @@ API_RESPONSE_MAC_ADDRESS = "macAddress" # Used as unique ID
 
 # Default values
 DEFAULT_NAME = "PoolSync" # Default name for the device
-DEFAULT_SCAN_INTERVAL = 60  # Default polling interval in seconds
+DEFAULT_SCAN_INTERVAL = 120  # Default polling interval in seconds
 
 # Headers required for API communication
 HEADER_AUTHORIZATION = "authorization"
@@ -39,11 +39,10 @@ PUSHLINK_CHECK_INTERVAL_S = 5  # How often to poll for pushlink status (seconds)
 PUSHLINK_TIMEOUT_S = 120       # How long to wait for the user to press the button (seconds)
 
 # Other constants
-HTTP_TIMEOUT = 25  # <<< Increased timeout for HTTP requests (seconds)
+HTTP_TIMEOUT = 30  # <<< Increased timeout for HTTP requests (seconds)
 
 # Platform
 PLATFORMS = ["sensor", "binary_sensor","number"]
 
 # Option keys
 OPTION_SCAN_INTERVAL = "scan_interval"
-

--- a/custom_components/poolsync_custom/const.py
+++ b/custom_components/poolsync_custom/const.py
@@ -39,7 +39,7 @@ PUSHLINK_TIMEOUT_S = 120       # How long to wait for the user to press the butt
 HTTP_TIMEOUT = 25  # <<< Increased timeout for HTTP requests (seconds)
 
 # Platform
-PLATFORMS = ["sensor", "binary_sensor"]
+PLATFORMS = ["sensor", "binary_sensor","number"]
 
 # Option keys
 OPTION_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/poolsync_custom/coordinator.py
+++ b/custom_components/poolsync_custom/coordinator.py
@@ -30,6 +30,8 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         update_interval_seconds: int,
         config_entry_id: str, # For logging/context
         mac_address: str,     # For unique device identification
+        heatpump_id: int,     # Heatpump id
+        chlorinator_id: int,  # chlorinator id
     ) -> None:
         """Initialize the data update coordinator."""
         self.api_client = api_client
@@ -68,6 +70,10 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             if not isinstance(data, dict) or not all(k in data for k in ["poolSync", "devices"]):
                 _LOGGER.error("Coordinator %s: Fetched data is not a dict or essential keys ('poolSync', 'devices') are missing. Data: %s", self.name, data)
                 raise UpdateFailed(f"Malformed data received from {self.name}: essential keys missing or data not a dict.")
+            if self.data and isinstance(self.data.get("deviceType"), dict):
+                deviceTypes = self.data["deviceType"]
+                self.heatpump_id = [key for key, value in device_type.items() if value == "heatPump"]
+                self.chlorinator_id = [key for key, value in device_type.items() if value == "chlorSync"]
             return data # Return the full data structure
 
         except PoolSyncApiAuthError as err:

--- a/custom_components/poolsync_custom/coordinator.py
+++ b/custom_components/poolsync_custom/coordinator.py
@@ -67,12 +67,6 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             if not isinstance(data, dict) or not all(k in data for k in ["poolSync", "devices"]):
                 _LOGGER.error("Coordinator %s: Fetched data is not a dict or essential keys ('poolSync', 'devices') are missing. Data: %s", self.name, data)
                 raise UpdateFailed(f"Malformed data received from {self.name}: essential keys missing or data not a dict.")
-            if self.data and isinstance(self.data.get("deviceType"), dict):
-                deviceTypes = self.data["deviceType"]
-                temp = [key for key, value in deviceTypes.items() if value == "heatPump"]
-                self.heatpump_id = temp[0] if temp else None
-                temp = [key for key, value in deviceTypes.items() if value == "chlorSync"]
-                self.chlorinator_id = temp[0] if temp else None
             return data # Return the full data structure
 
         except PoolSyncApiAuthError as err:

--- a/custom_components/poolsync_custom/coordinator.py
+++ b/custom_components/poolsync_custom/coordinator.py
@@ -73,7 +73,8 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             if self.data and isinstance(self.data.get("deviceType"), dict):
                 deviceTypes = self.data["deviceType"]
                 temp = [key for key, value in deviceTypes.items() if value == "heatPump"]
-                selfl.heatpump_id = temp[0] if temp else None
+                self.heatpump_id = temp[0] if temp else None
+                _Logger.info("Heatpump id: " + str(self.heatpump_id))
                 temp = [key for key, value in deviceTypes.items() if value == "chlorSync"]
                 self.chlorinator_id = temp[0] if temp else None
             return data # Return the full data structure

--- a/custom_components/poolsync_custom/coordinator.py
+++ b/custom_components/poolsync_custom/coordinator.py
@@ -72,8 +72,10 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 raise UpdateFailed(f"Malformed data received from {self.name}: essential keys missing or data not a dict.")
             if self.data and isinstance(self.data.get("deviceType"), dict):
                 deviceTypes = self.data["deviceType"]
-                self.heatpump_id = [key for key, value in device_type.items() if value == "heatPump"]
-                self.chlorinator_id = [key for key, value in device_type.items() if value == "chlorSync"]
+                temp = [key for key, value in deviceTypes.items() if value == "heatPump"]
+                selfl.heatpump_id = temp[0] if temp else None
+                temp = [key for key, value in deviceTypes.items() if value == "chlorSync"]
+                self.chlorinator_id = temp[0] if temp else None
             return data # Return the full data structure
 
         except PoolSyncApiAuthError as err:

--- a/custom_components/poolsync_custom/coordinator.py
+++ b/custom_components/poolsync_custom/coordinator.py
@@ -30,8 +30,6 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         update_interval_seconds: int,
         config_entry_id: str, # For logging/context
         mac_address: str,     # For unique device identification
-        heatpump_id: int,     # Heatpump id
-        chlorinator_id: int,  # chlorinator id
     ) -> None:
         """Initialize the data update coordinator."""
         self.api_client = api_client
@@ -55,8 +53,7 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             "PoolSync coordinator initialized for %s (MAC: %s, IP: %s) with update interval %d seconds",
             self.name, self.mac_address, self._ip_address, update_interval_seconds
         )
-
-
+            
     async def _async_update_data(self) -> Dict[str, Any]:
         """
         Fetch data from the PoolSync device API.
@@ -74,7 +71,6 @@ class PoolSyncDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 deviceTypes = self.data["deviceType"]
                 temp = [key for key, value in deviceTypes.items() if value == "heatPump"]
                 self.heatpump_id = temp[0] if temp else None
-                _Logger.info("Heatpump id: " + str(self.heatpump_id))
                 temp = [key for key, value in deviceTypes.items() if value == "chlorSync"]
                 self.chlorinator_id = temp[0] if temp else None
             return data # Return the full data structure

--- a/custom_components/poolsync_custom/number.py
+++ b/custom_components/poolsync_custom/number.py
@@ -2,9 +2,6 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
-heatpump_id = "0"
-chlorinator_id = "-1"
-
 from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
@@ -21,8 +18,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.exceptions import HomeAssistantError # For service call errors
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
+
 from .const import (
     DOMAIN,
+    CHLORINATOR_ID,
+    HEATPUMP_ID,
     #DEFAULT_CHLOR_OUTPUT_MIN,
     #DEFAULT_CHLOR_OUTPUT_MAX,
     #DEFAULT_CHLOR_OUTPUT_STEP,
@@ -43,7 +43,7 @@ NUMBER_DESCRIPTIONS_CHLOR: tuple[NumberEntityDescription, List[str], Optional[Ca
         native_max_value=100,#DEFAULT_CHLOR_OUTPUT_MAX, # e.g., 100
         native_step=1,#DEFAULT_CHLOR_OUTPUT_STEP,     # e.g., 1 or 5
         mode=NumberMode.SLIDER, # Or NumberMode.BOX
-    ), ["devices", chlorinator_id, "config", "chlorOutput"], None), # Path to get current value
+    ), ["devices", CHLORINATOR_ID, "config", "chlorOutput"], None), # Path to get current value
 )
 
 NUMBER_DESCRIPTIONS_HEATPUMP_F: tuple[NumberEntityDescription, List[str], Optional[Callable[[Any], Any]]] = (
@@ -56,7 +56,7 @@ NUMBER_DESCRIPTIONS_HEATPUMP_F: tuple[NumberEntityDescription, List[str], Option
         native_max_value=104, # e.g., 100
         native_step=1,     # e.g., 1 or 5
         mode=NumberMode.BOX, # Or NumberMode.BOX
-    ), ["devices", heatpump_id, "config", "setpoint"], None), # Path to get current value
+    ), ["devices", HEATPUMP_ID, "config", "setpoint"], None), # Path to get current value
     (NumberEntityDescription(
         key="heat_mode", #NUMBER_KEY_CHLOR_OUTPUT, # "chlor_output_control"
         name="heat_mode", # This will be the entity name
@@ -65,7 +65,7 @@ NUMBER_DESCRIPTIONS_HEATPUMP_F: tuple[NumberEntityDescription, List[str], Option
         native_max_value=2, # e.g., 100
         native_step=1,     # e.g., 1 or 5
         mode=NumberMode.BOX, # Or NumberMode.BOX
-    ), ["devices", heatpump_id, "config", "mode"], None), # Path to get current value
+    ), ["devices", HEATPUMP_ID, "config", "mode"], None), # Path to get current value
 )
 
 NUMBER_DESCRIPTIONS_HEATPUMP_C: tuple[NumberEntityDescription, List[str], Optional[Callable[[Any], Any]]] = (
@@ -78,7 +78,7 @@ NUMBER_DESCRIPTIONS_HEATPUMP_C: tuple[NumberEntityDescription, List[str], Option
         native_max_value=40, # e.g., 100
         native_step=0.5,     # e.g., 1 or 5
         mode=NumberMode.SLIDER, # Or NumberMode.BOX
-    ), ["devices", heatpump_id, "config", "setpoint"], None), # Path to get current value
+    ), ["devices", HEATPUMP_ID, "config", "setpoint"], None), # Path to get current value
     (NumberEntityDescription(
         key="heat_mode", #NUMBER_KEY_CHLOR_OUTPUT, # "chlor_output_control"
         name="heat_mode", # This will be the entity name
@@ -87,7 +87,7 @@ NUMBER_DESCRIPTIONS_HEATPUMP_C: tuple[NumberEntityDescription, List[str], Option
         native_max_value=2, # e.g., 100
         native_step=1,     # e.g., 1 or 5
         mode=NumberMode.BOX, # Or NumberMode.BOX
-    ), ["devices", heatpump_id, "config", "mode"], None), # Path to get current value
+    ), ["devices", HEATPUMP_ID, "config", "mode"], None), # Path to get current value
 )
 
 async def async_setup_entry(
@@ -120,9 +120,10 @@ async def async_setup_entry(
 
     _LOGGER.debug("NUMBER_PLATFORM: Coordinator data seems valid for device '0'. Proceeding to create number entities.")
 
-    _LOGGER.info("Making Number Sensor")
+    _LOGGER.info("XXXMaking Number Sensor: " + str(CHLORINATOR_ID))
     
-    if chlorinator_id is not "-1":
+    if CHLORINATOR_ID != "-1":
+        _LOGGER.info("XXX Why am I here: " + str(CHLORINATOR_ID))
         for description, data_path, value_fn in NUMBER_DESCRIPTIONS_CHLOR:
             _LOGGER.debug("NUMBER_PLATFORM: Processing number entity description for key: %s", description.key)
             current_value = _get_value_from_path(coordinator.data, data_path)
@@ -147,7 +148,7 @@ async def async_setup_entry(
 
     is_metric = hass.config.units is METRIC_SYSTEM
     _LOGGER.info("Making Heatpump Number Sensor")
-    if heatpump_id is not "-1":
+    if HEATPUMP_ID != "-1":
         if is_metric:
             number_descriptions_heatpump = NUMBER_DESCRIPTIONS_HEATPUMP_C
         else:

--- a/custom_components/poolsync_custom/sensor.py
+++ b/custom_components/poolsync_custom/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import DOMAIN
 from .coordinator import PoolSyncDataUpdateCoordinator
@@ -190,27 +191,30 @@ async def async_setup_entry(
         # Still attempt to add sensors; they will become unavailable if their specific data is missing.
     
     # change temperature unit
-    
+    # is_metric = hass.config.units is METRIC_SYSTEM
     
     
     heatpump_id = coordinator.heatpump_id
     chlorinator_id = coordinator.chlorinator_id
     
-    if heatpump_id is not None:
-        for description, data_path, value_fn in SENSOR_DESCRIPTIONS_POOLSYNC:
-            sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
+    
+    for description, data_path, value_fn in SENSOR_DESCRIPTIONS_POOLSYNC:
+        sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
     if chlorinator_id is not None:
         for description, data_path, value_fn in SENSOR_DESCRIPTIONS_CHLORSYNC:
             data_path[1] = chlorinator_id
+            #description = _change_temperature_unit(description, is_metric)
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
- 
-    for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:
-        _LOGGER.info("data_path")
-        _LOGGER.info(data_path)
-        data_path[1] = heatpump_id
-        _LOGGER.info(data_path)
-        sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
+    
+    if heatpump_id is not None:
+        for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:
+            _LOGGER.info("data_path")
+            _LOGGER.info(data_path)
+            data_path[1] = heatpump_id
+            _LOGGER.info(data_path)
+            #description = _change_temperature_unit(description, is_metric)
+            sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
         
     if sensors_to_add:
         async_add_entities(sensors_to_add)

--- a/custom_components/poolsync_custom/sensor.py
+++ b/custom_components/poolsync_custom/sensor.py
@@ -1,6 +1,10 @@
 """Sensor platform for the PoolSync Custom integration."""
 import logging
+import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
+
+chlorinator_id = "-1"
+heatpump_id = "0"
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -30,17 +34,13 @@ from .coordinator import PoolSyncDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-def description = _change_temperature_unit(description, is_metric):
+def _change_temperature_unit(description, is_metric):
     if is_metric:
         return description
         
-    for key, val in description:
-        if val.native_unit_of_measurement is not UnitOfTemperature.CELSIUS:
-            continue
-        description[key] = dataclasses.replace(
-            val,
-            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT ,
-        )
+    if description.native_unit_of_measurement is UnitOfTemperature.CELSIUS:      
+        description = dataclasses.replace(description,native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT)
+        
     return description
 
 
@@ -74,51 +74,51 @@ SENSOR_DESCRIPTIONS_CHLORSYNC: Tuple[Tuple[SensorEntityDescription, List[str], O
         key="water_temp", name="Water Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", "0", "status", "waterTemp"], None),
+    ), ["devices", chlorinator_id, "status", "waterTemp"], None),
     (SensorEntityDescription(
         key="salt_ppm", name="Salt Level", icon="mdi:shaker-outline",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION, state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-    ), ["devices", "0", "status", "saltPPM"], None),
+    ), ["devices", chlorinator_id, "status", "saltPPM"], None),
     (SensorEntityDescription(
-        key="flow_rate", name="Flow Rate", icon="mdi:pump", native_unit_of_measurement=None,
+        key="flow_rate", name="Chlor Flow Rate", icon="mdi:pump", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", "0", "status", "flowRate"], None),
+    ), ["devices", chlorinator_id, "status", "flowRate"], None),
     (SensorEntityDescription(
         key="chlor_output_setting", name="Chlorinator Output Setting", icon="mdi:percent-circle",
         native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", "0", "config", "chlorOutput"], None), # This is the sensor for the setting
+    ), ["devices", chlorinator_id, "config", "chlorOutput"], None), # This is the sensor for the setting
     (SensorEntityDescription(
         key="boost_remaining", name="Boost Time Remaining", icon="mdi:timer-sand", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", "0", "status", "boostRemaining"], None),
+    ), ["devices", chlorinator_id, "status", "boostRemaining"], None),
     (SensorEntityDescription(
         key="cell_fwd_current", name="Cell Forward Current", icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE, device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "status", "fwdCurrent"], None),
+    ), ["devices", chlorinator_id, "status", "fwdCurrent"], None),
     (SensorEntityDescription(
         key="cell_rev_current", name="Cell Reverse Current", icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE, device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "status", "revCurrent"], None),
+    ), ["devices", chlorinator_id, "status", "revCurrent"], None),
     (SensorEntityDescription(
         key="cell_output_voltage", name="Cell Output Voltage", icon="mdi:lightning-bolt",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT, device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "status", "outVoltage"], None),
+    ), ["devices", chlorinator_id, "status", "outVoltage"], None),
     (SensorEntityDescription(
         key="cell_serial_number", name="Cell Serial Number", icon="mdi:barcode-scan",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "system", "cellSerialNum"], None),
+    ), ["devices", chlorinator_id, "system", "cellSerialNum"], None),
     (SensorEntityDescription(
         key="cell_firmware_version", name="Cell Firmware Version", icon="mdi:chip",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "system", "cellFwVersion"], None),
+    ), ["devices", chlorinator_id, "system", "cellFwVersion"], None),
     (SensorEntityDescription(
         key="cell_hardware_version", name="Cell Hardware Version", icon="mdi:memory",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", "0", "system", "cellHwVersion"], None),
+    ), ["devices", chlorinator_id, "system", "cellHwVersion"], None),
 )
 SENSOR_DESCRIPTIONS_POOLSYNC: Tuple[Tuple[SensorEntityDescription, List[str], Optional[Callable[[Any], Any]]], ...] = (    
     # --- System Wide Sensors (data from `poolSync`) ---
@@ -157,26 +157,26 @@ SENSOR_DESCRIPTIONS_HEATPUMP: Tuple[Tuple[SensorEntityDescription, List[str], Op
         key="hp_water_temp", name="Water Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", "0", "status", "waterTemp"], None),
+    ), ["devices", heatpump_id, "status", "waterTemp"], None),
     (SensorEntityDescription(
         key="hp_air_temp", name="Air Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", "0", "status", "airTemp"], None),
+    ), ["devices", heatpump_id, "status", "airTemp"], None),
     (SensorEntityDescription(
         key="hp_outlet_temp", name="Outlet Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", "0", "status", "outletTemp"], None),
+    ), ["devices", heatpump_id, "status", "outletTemp"], None),
     (SensorEntityDescription(
         key="hp_mode", name="Mode", icon="mdi:pump", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", "0", "config", "mode"], None),
+    ), ["devices", heatpump_id, "config", "mode"], None),
     (SensorEntityDescription(
         key="hp_setpoint_temp", name="SetPoint Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", "0", "config", "setpoint"], None),
+    ), ["devices", heatpump_id, "config", "setpoint"], None),
 )
 
 async def async_setup_entry(
@@ -191,29 +191,19 @@ async def async_setup_entry(
         # Still attempt to add sensors; they will become unavailable if their specific data is missing.
     
     # change temperature unit
-    # is_metric = hass.config.units is METRIC_SYSTEM
-    
-    
-    heatpump_id = coordinator.heatpump_id
-    chlorinator_id = coordinator.chlorinator_id
-    
+    is_metric = hass.config.units is METRIC_SYSTEM
     
     for description, data_path, value_fn in SENSOR_DESCRIPTIONS_POOLSYNC:
         sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
-    if chlorinator_id is not None:
+    if chlorinator_id is not "-1":
         for description, data_path, value_fn in SENSOR_DESCRIPTIONS_CHLORSYNC:
-            data_path[1] = chlorinator_id
-            #description = _change_temperature_unit(description, is_metric)
+            description = _change_temperature_unit(description, is_metric)
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
-    if heatpump_id is not None:
-        for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:
-            _LOGGER.info("data_path")
-            _LOGGER.info(data_path)
-            data_path[1] = heatpump_id
-            _LOGGER.info(data_path)
-            #description = _change_temperature_unit(description, is_metric)
+    if heatpump_id is not "-1":
+        for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:         
+            description = _change_temperature_unit(description, is_metric)
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
         
     if sensors_to_add:

--- a/custom_components/poolsync_custom/sensor.py
+++ b/custom_components/poolsync_custom/sensor.py
@@ -198,7 +198,6 @@ async def async_setup_entry(
     
     if heatpump_id is not None:
         for description, data_path, value_fn in SENSOR_DESCRIPTIONS_POOLSYNC:
-            data_path[1] = heatpump_id
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
     if chlorinator_id is not None:
@@ -208,6 +207,8 @@ async def async_setup_entry(
  
     for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:
         _LOGGER.info("data_path")
+        _LOGGER.info(data_path)
+        data_path[1] = heatpump_id
         _LOGGER.info(data_path)
         sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
         

--- a/custom_components/poolsync_custom/sensor.py
+++ b/custom_components/poolsync_custom/sensor.py
@@ -3,9 +3,6 @@ import logging
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 
-chlorinator_id = "-1"
-heatpump_id = "0"
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -29,7 +26,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    CHLORINATOR_ID,
+    HEATPUMP_ID,
+)
+
 from .coordinator import PoolSyncDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,51 +76,51 @@ SENSOR_DESCRIPTIONS_CHLORSYNC: Tuple[Tuple[SensorEntityDescription, List[str], O
         key="water_temp", name="Water Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", chlorinator_id, "status", "waterTemp"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "waterTemp"], None),
     (SensorEntityDescription(
         key="salt_ppm", name="Salt Level", icon="mdi:shaker-outline",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION, state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-    ), ["devices", chlorinator_id, "status", "saltPPM"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "saltPPM"], None),
     (SensorEntityDescription(
         key="flow_rate", name="Chlor Flow Rate", icon="mdi:pump", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", chlorinator_id, "status", "flowRate"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "flowRate"], None),
     (SensorEntityDescription(
         key="chlor_output_setting", name="Chlorinator Output Setting", icon="mdi:percent-circle",
         native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", chlorinator_id, "config", "chlorOutput"], None), # This is the sensor for the setting
+    ), ["devices", CHLORINATOR_ID, "config", "chlorOutput"], None), # This is the sensor for the setting
     (SensorEntityDescription(
         key="boost_remaining", name="Boost Time Remaining", icon="mdi:timer-sand", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", chlorinator_id, "status", "boostRemaining"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "boostRemaining"], None),
     (SensorEntityDescription(
         key="cell_fwd_current", name="Cell Forward Current", icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE, device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "status", "fwdCurrent"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "fwdCurrent"], None),
     (SensorEntityDescription(
         key="cell_rev_current", name="Cell Reverse Current", icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE, device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "status", "revCurrent"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "revCurrent"], None),
     (SensorEntityDescription(
         key="cell_output_voltage", name="Cell Output Voltage", icon="mdi:lightning-bolt",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT, device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT, entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "status", "outVoltage"], None),
+    ), ["devices", CHLORINATOR_ID, "status", "outVoltage"], None),
     (SensorEntityDescription(
         key="cell_serial_number", name="Cell Serial Number", icon="mdi:barcode-scan",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "system", "cellSerialNum"], None),
+    ), ["devices", CHLORINATOR_ID, "system", "cellSerialNum"], None),
     (SensorEntityDescription(
         key="cell_firmware_version", name="Cell Firmware Version", icon="mdi:chip",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "system", "cellFwVersion"], None),
+    ), ["devices", CHLORINATOR_ID, "system", "cellFwVersion"], None),
     (SensorEntityDescription(
         key="cell_hardware_version", name="Cell Hardware Version", icon="mdi:memory",
         entity_registry_enabled_default=False, entity_category=EntityCategory.DIAGNOSTIC,
-    ), ["devices", chlorinator_id, "system", "cellHwVersion"], None),
+    ), ["devices", CHLORINATOR_ID, "system", "cellHwVersion"], None),
 )
 SENSOR_DESCRIPTIONS_POOLSYNC: Tuple[Tuple[SensorEntityDescription, List[str], Optional[Callable[[Any], Any]]], ...] = (    
     # --- System Wide Sensors (data from `poolSync`) ---
@@ -157,26 +159,26 @@ SENSOR_DESCRIPTIONS_HEATPUMP: Tuple[Tuple[SensorEntityDescription, List[str], Op
         key="hp_water_temp", name="Water Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", heatpump_id, "status", "waterTemp"], None),
+    ), ["devices", HEATPUMP_ID, "status", "waterTemp"], None),
     (SensorEntityDescription(
         key="hp_air_temp", name="Air Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", heatpump_id, "status", "airTemp"], None),
+    ), ["devices", HEATPUMP_ID, "status", "airTemp"], None),
     (SensorEntityDescription(
         key="hp_outlet_temp", name="Outlet Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", heatpump_id, "status", "outletTemp"], None),
+    ), ["devices", HEATPUMP_ID, "status", "outletTemp"], None),
     (SensorEntityDescription(
         key="hp_mode", name="Mode", icon="mdi:pump", native_unit_of_measurement=None,
         state_class=SensorStateClass.MEASUREMENT,
-    ), ["devices", heatpump_id, "config", "mode"], None),
+    ), ["devices", HEATPUMP_ID, "config", "mode"], None),
     (SensorEntityDescription(
         key="hp_setpoint_temp", name="SetPoint Temperature", icon="mdi:coolant-temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=1,
-    ), ["devices", heatpump_id, "config", "setpoint"], None),
+    ), ["devices", HEATPUMP_ID, "config", "setpoint"], None),
 )
 
 async def async_setup_entry(
@@ -196,12 +198,13 @@ async def async_setup_entry(
     for description, data_path, value_fn in SENSOR_DESCRIPTIONS_POOLSYNC:
         sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
-    if chlorinator_id is not "-1":
+    if CHLORINATOR_ID != "-1":
+        _LOGGER.info("YYY Why am I here")
         for description, data_path, value_fn in SENSOR_DESCRIPTIONS_CHLORSYNC:
             description = _change_temperature_unit(description, is_metric)
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))
     
-    if heatpump_id is not "-1":
+    if HEATPUMP_ID != "-1":
         for description, data_path, value_fn in SENSOR_DESCRIPTIONS_HEATPUMP:         
             description = _change_temperature_unit(description, is_metric)
             sensors_to_add.append(PoolSyncSensor(coordinator, description, data_path, value_fn))


### PR DESCRIPTION
Only tested with HeatPump as I do not have a ChlorSync. Still should support Chlorsync and added number entity back into Chlorsync. Finds and configures one or both devices automatically. Can set the Heatpump temperature and turn heat/cooling on/off. Template examples are in the readme to create swtiches